### PR TITLE
Make sure examples and readmes work in windows

### DIFF
--- a/challenges/main2.md
+++ b/challenges/main2.md
@@ -7,7 +7,7 @@ SPDX-License-Identifier: Apache-2.0
 
 This readme describes a flow to predict future ETH price via a local AI model.
 
-It is used for the second ETH Prediction Challenge. (Not announced yet.)
+It is used for the second ETH Prediction Challenge.
 
 - Kickoff: Nov 14, 2022
 - Submission deadline: Dec 11, 2022 at 23:59 UTC
@@ -33,11 +33,11 @@ Prerequisites:
 Now, let's install Python libraries. Open a terminal and:
 ```console
 # Initialize virtual environment and activate it.
-python3 -m venv venv
-source venv/bin/activate
+python3 -m venv venv #in Windows: python -m venv venv
+source venv/bin/activate #in Windows: venv\Scripts\activate
 
 # Avoid errors for the step that follows
-pip3 install wheel
+pip3 install wheel==0.37.1
 
 # Install Ocean library. Allow pre-releases to get the latest version.
 pip3 install --pre ocean-lib
@@ -57,9 +57,14 @@ You'll be using Polygon network. So, please ensure that you have a Polygon accou
 
 ### 1.3 Set envvars, for Polygon address
 
-In the terminal:
+In the terminal for Linux and Mac:
 ```console
 export REMOTE_TEST_PRIVATE_KEY1=<your Polygon private key>
+```
+
+In the terminal for Windows:
+```console
+set REMOTE_TEST_PRIVATE_KEY1=<your Polygon private key>
 ```
 
 ### 1.4 Load helper functions

--- a/challenges/main2.md
+++ b/challenges/main2.md
@@ -33,11 +33,15 @@ Prerequisites:
 Now, let's install Python libraries. Open a terminal and:
 ```console
 # Initialize virtual environment and activate it.
-python3 -m venv venv #in Windows: python -m venv venv
-source venv/bin/activate #in Windows: venv\Scripts\activate
+python3 -m venv venv (in Windows: python -m venv venv)
+source venv/bin/activate (in Windows: venv\Scripts\activate)
 
-# Avoid errors for the step that follows
-pip3 install wheel==0.37.1
+# If you have linux execute this command
+sudo apt-get install -y autoconf automake build-essential libffi-dev libtool pkg-config python3-dev
+
+# If you have apple execute this command
+xcode-select --install
+brew install autoconf automake libffi libtool pkg-config python
 
 # Install Ocean library. Allow pre-releases to get the latest version.
 pip3 install --pre ocean-lib

--- a/challenges/main2.md
+++ b/challenges/main2.md
@@ -36,10 +36,10 @@ Now, let's install Python libraries. Open a terminal and:
 python3 -m venv venv (in Windows: python -m venv venv)
 source venv/bin/activate (in Windows: venv\Scripts\activate)
 
-# If you have linux execute this command
+# If you have linux execute this:
 sudo apt-get install -y autoconf automake build-essential libffi-dev libtool pkg-config python3-dev
 
-# If you have apple execute this command
+# If you have apple execute this:
 xcode-select --install
 brew install autoconf automake libffi libtool pkg-config python
 

--- a/challenges/main2.md
+++ b/challenges/main2.md
@@ -47,7 +47,7 @@ brew install autoconf automake libffi libtool pkg-config python
 pip3 install --pre ocean-lib
 
 # Install other libraries
-pip3 install matplotlib pybundlr ccxt
+pip3 install matplotlib pybundlr ccxt requests
 ```
 
 You'll be using [Arweave Bundlr](https://docs.bundlr.network/docs/about/introduction) to share tamper-proof predictions. The `pybundlr` library (installed above) needs the Bundlr CLI installed. So, in the terminal:

--- a/examples/get-ethdata-binance-direct.md
+++ b/examples/get-ethdata-binance-direct.md
@@ -4,6 +4,12 @@ Here, we directly query the Binance API "Kline/Candlestick Data". [Here's the do
 
 We use Python [requests](https://requests.readthedocs.io/en/latest/) library to make queries.
 
+### 0. Setup
+
+From [Challenge 2](../challenges/main2.md), do:
+- [x] Setup
+
+
 ### 1. Get Data
 
 If the Python console isn't already open: `python`

--- a/examples/get-ethdata-binance-direct.md
+++ b/examples/get-ethdata-binance-direct.md
@@ -10,6 +10,11 @@ From [Challenge 2](../challenges/main2.md), do:
 - [x] Setup
 
 
+Install requests. Open a terminal and:
+```
+pip3 install requests
+```
+
 ### 1. Get Data
 
 If the Python console isn't already open: `python`

--- a/examples/get-ethdata-ccxt-binance.md
+++ b/examples/get-ethdata-ccxt-binance.md
@@ -7,13 +7,11 @@ Under the hood, ccxt queries the Binance API for Binance data.
 
 ### 0. Setup
 
+From [Challenge 2](../challenges/main2.md), do:
+- [x] Setup
+
 Install ccxt. Open a terminal and:
 ```
-# Initialize virtual environment and activate it.
-python3 -m venv venv
-source venv/bin/activate
-
-# Install libraries
 pip3 install ccxt
 ```
 

--- a/examples/model_example_direct_prediction.md
+++ b/examples/model_example_direct_prediction.md
@@ -1,9 +1,21 @@
 
 ### 1. Testing different models for direct price prediction from 1- 12 Hours
 
-Given the task of predicting ETH for 12 hours in the future, there are several approaches that are possible. These appraoches involce either learning an independent model to predict the prices at ech hour or to learn a model that makes direct predictions.
+Given the task of predicting ETH for 12 hours in the future, there are several approaches that are possible. These appraoches involve either learning an independent model to predict the prices at ech hour or to learn a model that makes direct predictions.
 
 This readme describe the implementation of four different algorithms to predict the price of ether uisng the previous values of it as features. The models use 12 previous hours prices to predict the 12 hours future values. The implemented models are Linear Regression, Random Forest regression, Support vector machines and a two layer desily connected neuran nework.
+
+## 1. Setup
+
+From [Challenge 2](../challenges/main2.md), do:
+- [x] Setup
+
+In the console:
+```console
+pip install pandas numpy requests
+```
+
+## 2. Create and open a python file
 
 ```python
 


### PR DESCRIPTION
Fixes #23.

Changes proposed in this PR:

- Updated all predict-eth readmes and examples to be DRY and ensure compatibility with windows, mac and linux
- in main2: replaced preinstalling wheel with the commands that prevent errors in mac and linux (step not needed in windows)
- web3 dependency can cause conflict because brownie and pybundlr use incompatible versions. Leave like this because this will be fixed in pybundlr