### PR TITLE
Fix #148 & #150: Remove brownie, update ocean.py usage

### DIFF
--- a/challenges/challenge-df.md
+++ b/challenges/challenge-df.md
@@ -236,7 +236,7 @@ print_datetime_info("target times", target_uts)
 data_nft_addr = <addr of your data NFT. Judges will find this from the chain>
 data_nft = DataNFT(ocean.config_dict, data_nft_addr)
 pred_vals_str_enc = data_nft.get_data("predictions")
-pred_vals_str = crypto.asym_decrypt(pred_vals_str_enc, alice.privateKey.hex())
+pred_vals_str = crypto.asym_decrypt(pred_vals_str_enc, alice._private_key.hex())
 pred_vals = [float(s) for s in pred_vals_str[1:-1].split(',')]
 
 # get actual ETH values (final)

--- a/challenges/challenge-df.md
+++ b/challenges/challenge-df.md
@@ -234,7 +234,7 @@ print_datetime_info("target times", target_uts)
 data_nft_addr = <addr of your data NFT. Judges will find this from the chain>
 data_nft = DataNFT(ocean.config_dict, data_nft_addr)
 pred_vals_str_enc = data_nft.get_data("predictions")
-pred_vals_str = crypto.asym_decrypt(pred_vals_str_enc, alice.private_key)
+pred_vals_str = crypto.asym_decrypt(pred_vals_str_enc, alice.privateKey.hex())
 pred_vals = [float(s) for s in pred_vals_str[1:-1].split(',')]
 
 # get actual ETH values (final)

--- a/challenges/challenge-df.md
+++ b/challenges/challenge-df.md
@@ -7,11 +7,11 @@ SPDX-License-Identifier: Apache-2.0
 
 ## 0. Introduction
 
-This README provides instructions to participate in Challenge Data Farming (DF). 
+This README provides instructions to participate in Challenge Data Farming (DF).
 
 ### 0.1 Prizes
 
-Prize Pool: 
+Prize Pool:
 - For DF48 (starts Jul 27) - DF61 (starts Oct 26): 5000 OCEAN, with 2500 / 1500 / 1000 OCEAN distributed to 1st / 2nd / 3rd place respectively.
 - For DF62 (starts Nov 2) - DF65 (starts Nov 30): 1000 OCEAN, with 500 / 300 / 200 OCEAN distributed to 1st / 2nd / 3rd place respectively.
 - Beyond: we recoommend to [run predictoor bots](https://github.com/oceanprotocol/pdr-backend/blob/main/READMEs/predictoor.md) to earn
@@ -182,10 +182,10 @@ token_id = 1
 tx = data_nft.safeTransferFrom(alice.address, judges_address, token_id, {"from": alice})
 
 # Ensure the transfer was successful
-assert tx.events['Transfer']['to'].lower() == judges_address.lower()
+assert get_transfer_event(ocean, data_nft, tx).args.to.lower() == judges_address.lower()
 
 # Print txid, as we'll use it in the next step
-print(f"txid from transferring the nft: {tx.txid}")
+print(f"txid from transferring the nft: {tx.transactionHash.hex()}")
 ```
 
 ## 4.3 Double-check that you submitted everything
@@ -209,6 +209,7 @@ In the terminal:
 
 ```console
 export REMOTE_TEST_PRIVATE_KEY1=<judges' private key, having address 0xA54A..>
+export RPC_URL=https://polygon.llamarpc.com  # or the RPC of your choice
 ```
 
 In the same Python console:
@@ -218,8 +219,9 @@ In the same Python console:
 from ocean_lib.models.data_nft import DataNFT
 from ocean_lib.ocean import crypto
 from predict_eth.helpers import *
+import os
 
-ocean = create_ocean_instance("polygon-test")
+ocean = create_ocean_instance(os.getenv("RPC_URL"))
 alice = create_alice_wallet(ocean) # the judge is Alice
 
 # specify target times

--- a/challenges/hack1.md
+++ b/challenges/hack1.md
@@ -149,7 +149,7 @@ In the same Python console:
 ```python
 from pybundlr import pybundlr
 file_name = "/tmp/pred_vals.csv"
-url = pybundlr.fund_and_upload(file_name, "matic", alice_wallet.privateKey.hex())
+url = pybundlr.fund_and_upload(file_name, "matic", alice_wallet._private_key.hex())
 #e.g. url = "https://arweave.net/qctEbPb3CjvU8LmV3G_mynX74eCxo1domFQIlOBH1xU"
 print(f"Your csv url: {url}")
 ```

--- a/challenges/hack1.md
+++ b/challenges/hack1.md
@@ -28,7 +28,7 @@ Here are the steps:
 Prerequisites:
 - Linux/MacOS
 - Python 3.8.5+
-- [Arweave Bundlr](https://docs.bundlr.network/docs/about/introduction): `npm install -g @bundlr-network/client` 
+- [Arweave Bundlr](https://docs.bundlr.network/docs/about/introduction): `npm install -g @bundlr-network/client`
 
 Now, let's install Python libraries. Open a terminal and:
 ```console
@@ -45,7 +45,7 @@ pip3 install ocean-lib matplotlib pybundlr ccxt
 
 ### 1.2 Create Polygon Account (One-Time)
 
-You'll be using Polygon network. So, please ensure that you have a Polygon account that holds some MATIC (at least a few $ worth). [More info](https://polygon.technology/matic-token/). 
+You'll be using Polygon network. So, please ensure that you have a Polygon account that holds some MATIC (at least a few $ worth). [More info](https://polygon.technology/matic-token/).
 
 ### 1.3 Set envvars, for Polygon address
 
@@ -74,7 +74,7 @@ Here, use whatever data you wish.
 
 It can be static data or streams, free or priced, raw data or feature vectors or otherwise. It can be published via Ocean, or not.
 
-The [main README](../README.md) links to some options. 
+The [main README](../README.md) links to some options.
 
 ## 3.  Make predictions
 
@@ -149,7 +149,7 @@ In the same Python console:
 ```python
 from pybundlr import pybundlr
 file_name = "/tmp/pred_vals.csv"
-url = pybundlr.fund_and_upload(file_name, "matic", alice_wallet.private_key)
+url = pybundlr.fund_and_upload(file_name, "matic", alice_wallet.privateKey.hex())
 #e.g. url = "https://arweave.net/qctEbPb3CjvU8LmV3G_mynX74eCxo1domFQIlOBH1xU"
 print(f"Your csv url: {url}")
 ```
@@ -234,7 +234,7 @@ import time
 
 import matplotlib
 import matplotlib.pyplot as plt
-    
+
 from ocean_lib.example_config import ExampleConfig
 from ocean_lib.ocean.ocean import Ocean
 from ocean_lib.web3_internal.wallet import Wallet
@@ -350,17 +350,17 @@ def load_list(file_name: str) -> list:
 def calc_nmse(y, yhat) -> float:
     assert len(y) == len(yhat)
     y, yhat = np.asarray(y), np.asarray(yhat)
-    range_y = max(y) - min(y)    
+    range_y = max(y) - min(y)
     nmse = np.sqrt(np.average(((yhat - y) / range_y) ** 2))
     return nmse
 
 
 def plot_prices(cex_vals, pred_vals):
     matplotlib.rcParams.update({'font.size': 22})
-    
+
     x = [h for h in range(0,12)]
     assert len(x) == len(cex_vals) == len(pred_vals)
-    
+
     fig, ax = plt.subplots()
     ax.plot(x, cex_vals, '--', label="CEX values")
     ax.plot(x, pred_vals, '-', label="Pred. values")

--- a/challenges/main1.md
+++ b/challenges/main1.md
@@ -11,7 +11,7 @@ It is used for [Predict-ETH Round 1 Data Challenge](https://blog.oceanprotocol.c
 
 - Kickoff: Oct 2, 2022
 - Submission deadline: Oct 16, 2022 at 23:59 UTC
-- Prediction at times: Oct 17, 2022 at 1:00 UTC, 2:00 UTC, ..., 23:00, 24:00. (24 predictions total). 
+- Prediction at times: Oct 17, 2022 at 1:00 UTC, 2:00 UTC, ..., 23:00, 24:00. (24 predictions total).
 - Winners announced: within one week
 
 Here are the steps:
@@ -28,7 +28,7 @@ Here are the steps:
 Prerequisites:
 - Linux/MacOS
 - Python 3.8.5+
-- [Arweave Bundlr](https://docs.bundlr.network/docs/about/introduction): `npm install -g @bundlr-network/client` 
+- [Arweave Bundlr](https://docs.bundlr.network/docs/about/introduction): `npm install -g @bundlr-network/client`
 
 Now, let's install Python libraries. Open a terminal and:
 ```console
@@ -48,7 +48,7 @@ pip3 install matplotlib pybundlr
 
 ### 1.2 Create Polygon Account (One-Time)
 
-You'll be using Polygon network. So, please ensure that you have a Polygon account that holds some MATIC (at least a few $ worth). [More info](https://polygon.technology/matic-token/). 
+You'll be using Polygon network. So, please ensure that you have a Polygon account that holds some MATIC (at least a few $ worth). [More info](https://polygon.technology/matic-token/).
 
 ### 1.3 Set envvars, for Polygon address
 
@@ -156,7 +156,7 @@ In the same Python console:
 ```python
 from pybundlr import pybundlr
 file_name = "/tmp/pred_vals.csv"
-url = pybundlr.fund_and_upload(file_name, "matic", alice_wallet.private_key)
+url = pybundlr.fund_and_upload(file_name, "matic", alice_wallet.privateKey.hex())
 #e.g. url = "https://arweave.net/qctEbPb3CjvU8LmV3G_mynX74eCxo1domFQIlOBH1xU"
 print(f"Your csv url: {url}")
 ```

--- a/challenges/main1.md
+++ b/challenges/main1.md
@@ -156,7 +156,7 @@ In the same Python console:
 ```python
 from pybundlr import pybundlr
 file_name = "/tmp/pred_vals.csv"
-url = pybundlr.fund_and_upload(file_name, "matic", alice_wallet.privateKey.hex())
+url = pybundlr.fund_and_upload(file_name, "matic", alice_wallet._private_key.hex())
 #e.g. url = "https://arweave.net/qctEbPb3CjvU8LmV3G_mynX74eCxo1domFQIlOBH1xU"
 print(f"Your csv url: {url}")
 ```

--- a/challenges/main2.md
+++ b/challenges/main2.md
@@ -5,7 +5,7 @@ SPDX-License-Identifier: Apache-2.0
 
 # Predict-ETH Round 2
 
-This is the main readme for the [Predict-ETH Round 2 Data Challenge](https://questbook.app/explore_grants/about_grant/?grantId=0x9f248741962aaf27bd10f2c50aeec2d13f343611&chainId=137). 
+This is the main readme for the [Predict-ETH Round 2 Data Challenge](https://questbook.app/explore_grants/about_grant/?grantId=0x9f248741962aaf27bd10f2c50aeec2d13f343611&chainId=137).
 
 - Kickoff: Nov 14, 2022
 - Submission deadline: Dec 11, 2022 at 23:59 UTC
@@ -35,7 +35,7 @@ Now, let's install Python libraries.
 pip3 install matplotlib pybundlr ccxt
 ```
 
-You'll be using [Arweave Bundlr](https://docs.bundlr.network/docs/about/introduction) to share tamper-proof predictions. The `pybundlr` library (installed above) needs the Bundlr CLI installed. So, in the terminal do the following. (If you encounter issues, please see the Appendix.) 
+You'll be using [Arweave Bundlr](https://docs.bundlr.network/docs/about/introduction) to share tamper-proof predictions. The `pybundlr` library (installed above) needs the Bundlr CLI installed. So, in the terminal do the following. (If you encounter issues, please see the Appendix.)
 ```
 npm install -g @bundlr-network/client
 ```
@@ -43,7 +43,7 @@ npm install -g @bundlr-network/client
 
 ### 1.2 Create Polygon Account (One-Time)
 
-You'll be using Polygon network. So, please ensure that you have a Polygon account that holds some MATIC (at least a few $ worth). [More info](https://polygon.technology/matic-token/). 
+You'll be using Polygon network. So, please ensure that you have a Polygon account that holds some MATIC (at least a few $ worth). [More info](https://polygon.technology/matic-token/).
 
 ### 1.3 Set envvars, for Polygon address
 
@@ -81,13 +81,13 @@ Here, use whatever data you wish.
 
 It can be static data or streams, free or priced, raw data or feature vectors or otherwise. It can be published via Ocean, or not.
 
-The [main README](../README.md) links to some options. 
+The [main README](../README.md) links to some options.
 
 ## 3.  Make predictions
 
 ### 3.1  Build a simple AI model
 
-Here, build whatever AI/ML model you want, leveraging the data from the previous step. The [main README](../README.md) links to some options. 
+Here, build whatever AI/ML model you want, leveraging the data from the previous step. The [main README](../README.md) links to some options.
 
 This demo flow skips building a model because the next step will simply generate random predictions.
 
@@ -156,7 +156,7 @@ In the same Python console:
 ```python
 from pybundlr import pybundlr
 file_name = "/tmp/pred_vals.csv"
-url = pybundlr.fund_and_upload(file_name, "matic", alice_wallet.private_key)
+url = pybundlr.fund_and_upload(file_name, "matic", alice_wallet.privateKey.hex())
 #e.g. url = "https://arweave.net/qctEbPb3CjvU8LmV3G_mynX74eCxo1domFQIlOBH1xU"
 print(f"Your csv url: {url}")
 ```
@@ -210,7 +210,7 @@ print_datetime_info("target times", target_uts)
 
 # get predicted ETH values
 did = <value shared by you>
-order_tx_id = ocean.assets.pay_for_access_service(ddo, alice_wallet)
+order_tx_id = ocean.assets.pay_for_access_service(ddo, alice_wallet).hex()
 file_name = ocean.assets.download_asset(ddo, alice_wallet, './', order_tx_id)
 pred_vals = load_list(file_name)
 
@@ -233,8 +233,8 @@ plot_prices(cex_vals, pred_vals)
 
 ### Appendix: If you have Arweave / Bundlr issues
 
-This README has you upload to Arweave permanent decentralized file storage, so that predictions are tamper-proof. Above, it provided instructions to install Bundlr, which wraps Arweave. 
+This README has you upload to Arweave permanent decentralized file storage, so that predictions are tamper-proof. Above, it provided instructions to install Bundlr, which wraps Arweave.
 
-If you encountered issues installing it, then you need to upload to Arweave in a different way. At the end of the process, you need a shareable url. The Arweave ecosystem has several webapps that you might consider. One of the leading apps is ArDrive. [Here's an ArDrive tutorial](https://docs.rawrshak.io/tutorials/developer/rawrshak-dapp/upload-data-to-arweave) to get going. 
+If you encountered issues installing it, then you need to upload to Arweave in a different way. At the end of the process, you need a shareable url. The Arweave ecosystem has several webapps that you might consider. One of the leading apps is ArDrive. [Here's an ArDrive tutorial](https://docs.rawrshak.io/tutorials/developer/rawrshak-dapp/upload-data-to-arweave) to get going.
 
 

--- a/challenges/main2.md
+++ b/challenges/main2.md
@@ -156,7 +156,7 @@ In the same Python console:
 ```python
 from pybundlr import pybundlr
 file_name = "/tmp/pred_vals.csv"
-url = pybundlr.fund_and_upload(file_name, "matic", alice_wallet.privateKey.hex())
+url = pybundlr.fund_and_upload(file_name, "matic", alice_wallet._private_key.hex())
 #e.g. url = "https://arweave.net/qctEbPb3CjvU8LmV3G_mynX74eCxo1domFQIlOBH1xU"
 print(f"Your csv url: {url}")
 ```

--- a/challenges/main3.md
+++ b/challenges/main3.md
@@ -56,18 +56,18 @@ pip3 install ccxt eth_account matplotlib numpy pandas prophet requests sklearn
 
 ### 1.4 Arweave preparation
 
-To share tamper-proof predictions, the READMEs use Arweave. You have two options, A and B. Please pick one and do the "prepare by" step. 
+To share tamper-proof predictions, the READMEs use Arweave. You have two options, A and B. Please pick one and do the "prepare by" step.
 
 **Option A: Webapp, using [ardrive.io](https://www.ardrive.io)**
   - Pros: simple webapp
   - Cons: need AR to pay for storage.
   - Prepare by: get AR via [a faucet](https://faucet.arweave.net/) or [buying some](https://www.google.com/search?q=buy+arweave+tokens). For more details follow [this](https://docs.oceanprotocol.com/using-ocean-market/asset-hosting#arweave
 ) tutorial.
-  
+
 **Option B: In code, using pybundlr library**
   - Pros: pay for storage with MATIC, ETH, AR, or [other](https://docs.bundlr.network/sdk/using-other-currencies). (But not fake MATIC)
   - Cons: bundlr CLI installation is finicky, since it needs "`npm install`" globally on your system (`-g` flag)
-  - Prepare by: 
+  - Prepare by:
     - in console, install pybundlr: `pip install pybundlr`
     - in console, install [Bundlr CLI](https://docs.bundlr.network/about/introduction): `npm install -g @bundlr-network/client`
     - get one of: [MATIC](https://polygon.technology/matic-token/), [ETH](https://ethereum.org/en/get-eth/), or AR (see "get AR via" above)
@@ -97,7 +97,7 @@ This demo flow skips getting data because it will generate random predictions (n
 
 ### 3.1  Build a simple AI model
 
-Here, build whatever AI/ML model you want, leveraging the data from the previous step. The [main README](../README.md) links to some options. 
+Here, build whatever AI/ML model you want, leveraging the data from the previous step. The [main README](../README.md) links to some options.
 
 This demo flow skips building a model because it will generate random predictions (no model needed).
 
@@ -172,7 +172,7 @@ Then, in the same Python console:
 ```python
 url = <url of uploaded file>
 ```
-  
+
 **Option B: In code, using pybundlr library**
 
 In the same Python console:
@@ -224,14 +224,16 @@ Now, you're complete! Thanks for being part of this competition.
 In the terminal:
 ```console
 export REMOTE_TEST_PRIVATE_KEY1=<judges' private key, having address 0xA54A..>
+export RPC_URL=https://polygon.llamarpc.com  # or the RPC of your choice
 ```
 
 In the same Python console:
 ```python
 # setup
 from predict_eth.helpers import *
+import os
 
-ocean = create_ocean_instance("polygon-test") # change the network name if needed
+ocean = create_ocean_instance(os.getenv("RPC_URL")) # change the network name if needed
 alice = create_alice_wallet(ocean) #you're Alice
 
 # specify target times

--- a/challenges/main3.md
+++ b/challenges/main3.md
@@ -182,7 +182,7 @@ file_name = "/tmp/pred_vals.csv"
 
 # This step assumes "matic" currency. You could also use "eth", "ar", etc.
 # Whatever network you choose, alice's wallet needs the corresponding funds.
-url = pybundlr.fund_and_upload(file_name, "matic", alice_wallet.privateKey.hex())
+url = pybundlr.fund_and_upload(file_name, "matic", alice_wallet._private_key.hex())
 
 #e.g. url = "https://arweave.net/qctEbPb3CjvU8LmV3G_mynX74eCxo1domFQIlOBH1xU"
 print(f"Your csv url: {url}")

--- a/challenges/main3.md
+++ b/challenges/main3.md
@@ -182,7 +182,7 @@ file_name = "/tmp/pred_vals.csv"
 
 # This step assumes "matic" currency. You could also use "eth", "ar", etc.
 # Whatever network you choose, alice's wallet needs the corresponding funds.
-url = pybundlr.fund_and_upload(file_name, "matic", alice_wallet.private_key)
+url = pybundlr.fund_and_upload(file_name, "matic", alice_wallet.privateKey.hex())
 
 #e.g. url = "https://arweave.net/qctEbPb3CjvU8LmV3G_mynX74eCxo1domFQIlOBH1xU"
 print(f"Your csv url: {url}")

--- a/challenges/main4.md
+++ b/challenges/main4.md
@@ -24,7 +24,7 @@ To be eligible, competitors must produce the outcomes that this README guides. T
 - :white_check_mark: Created an Ocean data NFT
 - :white_check_mark: On the data NFT, set a value correctly: correct field label, correct # predictions, prediction values following correct formatting, predictions encrypted with proper encoding on judges' public key
 - :white_check_mark: Transferred data NFT to Ocean judges before the submission deadline
-- :white_check_mark: Submitted txid of this transfer to the Desights platform 
+- :white_check_mark: Submitted txid of this transfer to the Desights platform
 - :white_check_mark: All on _Mumbai_ network, not another network
 
 The following are _not_ criteria:
@@ -34,7 +34,7 @@ The following are _not_ criteria:
 
 ### 0.3 Developer Support, Workshops, Chat
 
-**Support.** If you encounter issues, feel free to reach out :raised_hand: 
+**Support.** If you encounter issues, feel free to reach out :raised_hand:
 - in Desights' [#dev-support Discord](https://discord.com/channels/1032236056516509706/1069484636167749662)
 - in Ocean's [#dev-support Discord](https://discord.com/channels/612953348487905282/720631837122363412)
 
@@ -67,12 +67,12 @@ Desights is a decentralized platform for data science competitions. It hosts pre
 
 First, sign up to Desights _Discord_, if needed:
 - Go to [Desights Discord](https://discord.com/channels/1032236056516509706)
-- Enter your usual Discord info: email, password, etc.  
+- Enter your usual Discord info: email, password, etc.
 - And you're in!
 
 Then, sign up for Desights _Platform_, if needed:
 - Go to [Desights Discord #invitees channel](https://discord.com/channels/1032236056516509706/1076727165372084244)
-- Post a public message tagging admins, asking for access. 
+- Post a public message tagging admins, asking for access.
   - Example: "Hello @admin could you please send me an invite, to join the Desights AI platform please? Here is my ETH address: 0x(your address here)".
   - If you prefer, don't post your Eth address, and the admin will ask you for it in a private DM
 - The admin will respond with something like: "Your wallet is now invited to join the Desights AI platform  🤩🤗. Go ahead and create your Profile 🎊 at https://desights.ai/. Good luck with challenge"
@@ -128,7 +128,7 @@ This demo flow skips getting data because it will generate random predictions (n
 
 ### 3.1  Build a simple AI model
 
-Here, build whatever AI/ML model you want, leveraging the data from the previous step. The [main README](../README.md) links to some options. 
+Here, build whatever AI/ML model you want, leveraging the data from the previous step. The [main README](../README.md) links to some options.
 
 This demo flow skips building a model because it will generate random predictions (no model needed).
 
@@ -187,7 +187,7 @@ from ocean_lib.ocean import crypto
 data_nft = ocean.data_nft_factory.create({"from": alice}, 'Data NFT 1', 'DN1')
 print(f"Created data NFT with address={data_nft.address}")
 
-# Encrypt predictions with judges' public key, so competitors can't see. 
+# Encrypt predictions with judges' public key, so competitors can't see.
 # NOTE: public key is *not* the same thing as address. Using address will not work.
 judges_pubkey = '0x3d87bf8bde8c093a16ca5441b5a1053d34a28aca75dc4afffb7a2a513f2a16d2ac41bac68d8fc53058ed4846de25064098bbfaf0e1a5979aeb98028ce69fab6a'
 pred_vals_str = str(pred_vals)
@@ -202,10 +202,10 @@ token_id = 1
 tx = data_nft.safeTransferFrom(alice.address, judges_address, token_id, {"from": alice})
 
 # Ensure the transfer was successful
-assert tx.events['Transfer']['to'].lower() == judges_address.lower()
+assert get_transfer_event(ocean, data_nft, tx).args.to.lower() == judges_address.lower()
 
 # Print txid, as we'll use it in the next step
-print(f"txid from transferring the nft: {tx.txid}")
+print(f"txid from transferring the nft: {tx.transactionHash.hex()}")
 ````
 
 ## 4.2  Submit your result in Desights platform
@@ -229,6 +229,7 @@ Congratulations! You've now made your submission to the challenge! :tada:
 In the terminal:
 ```console
 export REMOTE_TEST_PRIVATE_KEY1=<judges' private key, having address 0xA54A..>
+export RPC_URL=https://polygon.llamarpc.com  # or the RPC of your choice
 ```
 
 In the same Python console:
@@ -237,8 +238,9 @@ In the same Python console:
 from ocean_lib.models.data_nft import DataNFT
 from ocean_lib.ocean import crypto
 from predict_eth.helpers import *
+import os
 
-ocean = create_ocean_instance("polygon-test")
+ocean = create_ocean_instance(os.getenv("RPC_URL"))
 alice = create_alice_wallet(ocean) # the judge is Alice
 
 # specify target times

--- a/challenges/main4.md
+++ b/challenges/main4.md
@@ -253,7 +253,7 @@ print_datetime_info("target times", target_uts)
 data_nft_addr = <addr of your data NFT. Judges will find this from the chain>
 data_nft = DataNFT(ocean.config_dict, data_nft_addr)
 pred_vals_str_enc = data_nft.get_data("predictions")
-pred_vals_str = crypto.asym_decrypt(pred_vals_str_enc, alice.privateKey.hex())
+pred_vals_str = crypto.asym_decrypt(pred_vals_str_enc, alice._private_key.hex())
 pred_vals = [float(s) for s in pred_vals_str[1:-1].split(',')]
 
 # get actual ETH values (final)

--- a/challenges/main4.md
+++ b/challenges/main4.md
@@ -253,7 +253,7 @@ print_datetime_info("target times", target_uts)
 data_nft_addr = <addr of your data NFT. Judges will find this from the chain>
 data_nft = DataNFT(ocean.config_dict, data_nft_addr)
 pred_vals_str_enc = data_nft.get_data("predictions")
-pred_vals_str = crypto.asym_decrypt(pred_vals_str_enc, alice.private_key)
+pred_vals_str = crypto.asym_decrypt(pred_vals_str_enc, alice.privateKey.hex())
 pred_vals = [float(s) for s in pred_vals_str[1:-1].split(',')]
 
 # get actual ETH values (final)

--- a/challenges/main5.md
+++ b/challenges/main5.md
@@ -228,7 +228,7 @@ print_datetime_info("target times", target_uts)
 data_nft_addr = <addr of your data NFT. Judges will find this from the chain>
 data_nft = DataNFT(ocean.config_dict, data_nft_addr)
 pred_vals_str_enc = data_nft.get_data("predictions")
-pred_vals_str = crypto.asym_decrypt(pred_vals_str_enc, alice.private_key)
+pred_vals_str = crypto.asym_decrypt(pred_vals_str_enc, alice.privateKey.hex())
 pred_vals = [float(s) for s in pred_vals_str[1:-1].split(',')]
 
 # get actual ETH values (final)

--- a/challenges/main5.md
+++ b/challenges/main5.md
@@ -228,7 +228,7 @@ print_datetime_info("target times", target_uts)
 data_nft_addr = <addr of your data NFT. Judges will find this from the chain>
 data_nft = DataNFT(ocean.config_dict, data_nft_addr)
 pred_vals_str_enc = data_nft.get_data("predictions")
-pred_vals_str = crypto.asym_decrypt(pred_vals_str_enc, alice.privateKey.hex())
+pred_vals_str = crypto.asym_decrypt(pred_vals_str_enc, alice._private_key.hex())
 pred_vals = [float(s) for s in pred_vals_str[1:-1].split(',')]
 
 # get actual ETH values (final)

--- a/challenges/main5.md
+++ b/challenges/main5.md
@@ -37,13 +37,13 @@ To be eligible, competitors must produce the outcomes that this README guides. T
 
 ### 0.4 Developer Support
 
-**Support.** If you encounter issues, feel free to reach out :raised_hand: 
+**Support.** If you encounter issues, feel free to reach out :raised_hand:
 - [Ocean #dev-support Discord](https://discord.com/channels/612953348487905282/720631837122363412)
 - [Ocean #data-challenges Discord](https://discord.com/channels/612953348487905282/993828971408003152).
 
 ### 0.5 Workshops
 
-We host workshops to walk through READMEs, and hold Q&A with our core team. 
+We host workshops to walk through READMEs, and hold Q&A with our core team.
 
 Dates:
 - Apr 25 at 3PM UTC (8 days before deadline of Wed May 3)
@@ -109,7 +109,7 @@ This demo flow skips getting data because it will generate random predictions (n
 
 ### 3.1  Build a simple AI model
 
-Here, build whatever AI/ML model you want, leveraging the data from the previous step. The [main README](../README.md) links to some options. 
+Here, build whatever AI/ML model you want, leveraging the data from the previous step. The [main README](../README.md) links to some options.
 
 This demo flow skips building a model because it will generate random predictions (no model needed).
 
@@ -168,7 +168,7 @@ from ocean_lib.ocean import crypto
 data_nft = ocean.data_nft_factory.create({"from": alice}, 'Data NFT 1', 'DN1')
 print(f"Created data NFT with address={data_nft.address}")
 
-# Encrypt predictions with judges' public key, so competitors can't see. 
+# Encrypt predictions with judges' public key, so competitors can't see.
 # NOTE: public key is *not* the same thing as address. Using address will not work.
 judges_pubkey = '0x3d87bf8bde8c093a16ca5441b5a1053d34a28aca75dc4afffb7a2a513f2a16d2ac41bac68d8fc53058ed4846de25064098bbfaf0e1a5979aeb98028ce69fab6a'
 pred_vals_str = str(pred_vals)
@@ -183,10 +183,10 @@ token_id = 1
 tx = data_nft.safeTransferFrom(alice.address, judges_address, token_id, {"from": alice})
 
 # Ensure the transfer was successful
-assert tx.events['Transfer']['to'].lower() == judges_address.lower()
+assert get_transfer_event(ocean, data_nft, tx).args.to.lower() == judges_address.lower()
 
 # Print txid, as we'll use it in the next step
-print(f"txid from transferring the nft: {tx.txid}")
+print(f"txid from transferring the nft: {tx.transactionHash.hex()}")
 ````
 
 ## 4.3 Double-check that you submitted everything
@@ -204,6 +204,7 @@ Congratulations! You've now made your submission to the challenge! :tada:
 In the terminal:
 ```console
 export REMOTE_TEST_PRIVATE_KEY1=<judges' private key, having address 0xA54A..>
+export RPC_URL=https://polygon.llamarpc.com  # or the RPC of your choice
 ```
 
 In the same Python console:
@@ -212,8 +213,9 @@ In the same Python console:
 from ocean_lib.models.data_nft import DataNFT
 from ocean_lib.ocean import crypto
 from predict_eth.helpers import *
+import os
 
-ocean = create_ocean_instance("polygon-test")
+ocean = create_ocean_instance(os.getenv("RPC_URL"))
 alice = create_alice_wallet(ocean) # the judge is Alice
 
 # specify target times

--- a/challenges/main6.md
+++ b/challenges/main6.md
@@ -220,7 +220,7 @@ print_datetime_info("target times", target_uts)
 data_nft_addr = <addr of your data NFT. Judges will find this from the chain>
 data_nft = DataNFT(ocean.config_dict, data_nft_addr)
 pred_vals_str_enc = data_nft.get_data("predictions")
-pred_vals_str = crypto.asym_decrypt(pred_vals_str_enc, alice.private_key)
+pred_vals_str = crypto.asym_decrypt(pred_vals_str_enc, alice.privateKey.hex())
 pred_vals = [float(s) for s in pred_vals_str[1:-1].split(',')]
 
 # get actual ETH values (final)

--- a/challenges/main6.md
+++ b/challenges/main6.md
@@ -37,14 +37,14 @@ If there is >1 submission by the same address, then the most recent one (that st
 
 ### 0.4 Developer Support
 
-**Support.** If you encounter issues, feel free to reach out :raised_hand: 
+**Support.** If you encounter issues, feel free to reach out :raised_hand:
 - [Ocean #dev-support Discord](https://discord.com/channels/612953348487905282/720631837122363412)
 - [Ocean #data-challenges Discord](https://discord.com/channels/612953348487905282/993828971408003152).
 
 ### 0.5 Workshops
 
 We host a workshop to walk through READMEs, and hold Q&A with our core team.
-- When: May 27 at 3PM UTC (8 days before deadline of Wed Jun 7) 
+- When: May 27 at 3PM UTC (8 days before deadline of Wed Jun 7)
 - Where: [Special event on Ocean Discord](https://discord.com/invite/5VWDytWG?event=1097944942564876409)
 
 ### 0.6 Outline of this README
@@ -103,7 +103,7 @@ This demo flow skips getting data because it will generate random predictions (n
 
 ### 3.1  Build a simple AI model
 
-Here, build whatever AI/ML model you want, leveraging the data from the previous step. The [main README](../README.md) links to some options. 
+Here, build whatever AI/ML model you want, leveraging the data from the previous step. The [main README](../README.md) links to some options.
 
 This demo flow skips building a model because it will generate random predictions (no model needed).
 
@@ -162,7 +162,7 @@ from ocean_lib.ocean import crypto
 data_nft = ocean.data_nft_factory.create({"from": alice}, 'Data NFT 1', 'DN1')
 print(f"Created data NFT with address={data_nft.address}")
 
-# Encrypt predictions with judges' public key, so competitors can't see. 
+# Encrypt predictions with judges' public key, so competitors can't see.
 # NOTE: public key is *not* the same thing as address. Using address will not work.
 judges_pubkey = '0x3d87bf8bde8c093a16ca5441b5a1053d34a28aca75dc4afffb7a2a513f2a16d2ac41bac68d8fc53058ed4846de25064098bbfaf0e1a5979aeb98028ce69fab6a'
 pred_vals_str = str(pred_vals)
@@ -177,10 +177,10 @@ token_id = 1
 tx = data_nft.safeTransferFrom(alice.address, judges_address, token_id, {"from": alice})
 
 # Ensure the transfer was successful
-assert tx.events['Transfer']['to'].lower() == judges_address.lower()
+assert get_transfer_event(ocean, data_nft, tx).args.to.lower() == judges_address.lower()
 
 # Print txid, as we'll use it in the next step
-print(f"txid from transferring the nft: {tx.txid}")
+print(f"txid from transferring the nft: {tx.transactionHash.hex()}")
 ````
 
 ## 4.3 Double-check that you submitted everything

--- a/challenges/main6.md
+++ b/challenges/main6.md
@@ -220,7 +220,7 @@ print_datetime_info("target times", target_uts)
 data_nft_addr = <addr of your data NFT. Judges will find this from the chain>
 data_nft = DataNFT(ocean.config_dict, data_nft_addr)
 pred_vals_str_enc = data_nft.get_data("predictions")
-pred_vals_str = crypto.asym_decrypt(pred_vals_str_enc, alice.privateKey.hex())
+pred_vals_str = crypto.asym_decrypt(pred_vals_str_enc, alice._private_key.hex())
 pred_vals = [float(s) for s in pred_vals_str[1:-1].split(',')]
 
 # get actual ETH values (final)

--- a/challenges/main7.md
+++ b/challenges/main7.md
@@ -216,7 +216,7 @@ print_datetime_info("target times", target_uts)
 data_nft_addr = <addr of your data NFT. Judges will find this from the chain>
 data_nft = DataNFT(ocean.config_dict, data_nft_addr)
 pred_vals_str_enc = data_nft.get_data("predictions")
-pred_vals_str = crypto.asym_decrypt(pred_vals_str_enc, alice.private_key)
+pred_vals_str = crypto.asym_decrypt(pred_vals_str_enc, alice.privateKey.hex())
 pred_vals = [float(s) for s in pred_vals_str[1:-1].split(',')]
 
 # get actual ETH values (final)

--- a/challenges/main7.md
+++ b/challenges/main7.md
@@ -37,7 +37,7 @@ If there is >1 submission by the same address, then the most recent one (that st
 
 ### 0.4 Developer Support
 
-**Support.** If you encounter issues, feel free to reach out :raised_hand: 
+**Support.** If you encounter issues, feel free to reach out :raised_hand:
 - [Ocean #dev-support Discord](https://discord.com/channels/612953348487905282/720631837122363412)
 - [Ocean #data-challenges Discord](https://discord.com/channels/612953348487905282/993828971408003152).
 
@@ -97,7 +97,7 @@ This demo flow skips getting data because it will generate random predictions (n
 
 ### 3.1  Build a simple AI model
 
-Here, build whatever AI/ML model you want, leveraging the data from the previous step. The [main README](../README.md) links to some options. 
+Here, build whatever AI/ML model you want, leveraging the data from the previous step. The [main README](../README.md) links to some options.
 
 This demo flow skips building a model because it will generate random predictions (no model needed).
 
@@ -156,7 +156,7 @@ from ocean_lib.ocean import crypto
 data_nft = ocean.data_nft_factory.create({"from": alice}, 'Data NFT 1', 'DN1')
 print(f"Created data NFT with address={data_nft.address}")
 
-# Encrypt predictions with judges' public key, so competitors can't see. 
+# Encrypt predictions with judges' public key, so competitors can't see.
 # NOTE: public key is *not* the same thing as address. Using address will not work.
 judges_pubkey = '0x3d87bf8bde8c093a16ca5441b5a1053d34a28aca75dc4afffb7a2a513f2a16d2ac41bac68d8fc53058ed4846de25064098bbfaf0e1a5979aeb98028ce69fab6a'
 pred_vals_str = str(pred_vals)
@@ -171,10 +171,10 @@ token_id = 1
 tx = data_nft.safeTransferFrom(alice.address, judges_address, token_id, {"from": alice})
 
 # Ensure the transfer was successful
-assert tx.events['Transfer']['to'].lower() == judges_address.lower()
+assert get_transfer_event(ocean, data_nft, tx).args.to.lower() == judges_address.lower()
 
 # Print txid, as we'll use it in the next step
-print(f"txid from transferring the nft: {tx.txid}")
+print(f"txid from transferring the nft: {tx.transactionHash.hex()}")
 ````
 
 ## 4.3 Double-check that you submitted everything
@@ -192,6 +192,7 @@ Congratulations! You've now made your submission to the challenge! :tada:
 In the terminal:
 ```console
 export REMOTE_TEST_PRIVATE_KEY1=<judges' private key, having address 0xA54A..>
+export RPC_URL=https://polygon.llamarpc.com  # or the RPC of your choice
 ```
 
 In the same Python console:
@@ -200,8 +201,9 @@ In the same Python console:
 from ocean_lib.models.data_nft import DataNFT
 from ocean_lib.ocean import crypto
 from predict_eth.helpers import *
+import os
 
-ocean = create_ocean_instance("polygon-test")
+ocean = create_ocean_instance(os.getenv("RPC_URL"))
 alice = create_alice_wallet(ocean) # the judge is Alice
 
 # specify target times

--- a/challenges/main7.md
+++ b/challenges/main7.md
@@ -216,7 +216,7 @@ print_datetime_info("target times", target_uts)
 data_nft_addr = <addr of your data NFT. Judges will find this from the chain>
 data_nft = DataNFT(ocean.config_dict, data_nft_addr)
 pred_vals_str_enc = data_nft.get_data("predictions")
-pred_vals_str = crypto.asym_decrypt(pred_vals_str_enc, alice.privateKey.hex())
+pred_vals_str = crypto.asym_decrypt(pred_vals_str_enc, alice._private_key.hex())
 pred_vals = [float(s) for s in pred_vals_str[1:-1].split(',')]
 
 # get actual ETH values (final)

--- a/examples/get-ethdata-ocean-thegraph.md
+++ b/examples/get-ethdata-ocean-thegraph.md
@@ -23,7 +23,7 @@ ETH_USDT_datatoken = ocean.get_datatoken(ETH_USDT_ddo.datatokens[0]["address"])
 
 from ocean_lib.ocean.util import to_wei
 ETH_USDT_datatoken.dispense(to_wei(1), {"from":alice_wallet})
-order_tx_id = ocean.assets.pay_for_access_service(ETH_USDT_ddo, {"from": alice_wallet})
+order_tx_id = ocean.assets.pay_for_access_service(ETH_USDT_ddo, {"from": alice_wallet}).hex()
 file_name = ocean.assets.download_asset(ETH_USDT_ddo, alice_wallet,"./", order_tx_id)
 
 # Each item in the json file has 8 entries:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,4 @@
-eth-brownie>=1.19.3
 matplotlib
 numpy
 ocean-lib
 pytest
-web3>=5.28.0
-


### PR DESCRIPTION
This PR does two things:
- Fix [#148](https://github.com/oceanprotocol/predict-eth/issues/148) -- remove brownie dependencies
- Fix [#150](https://github.com/oceanprotocol/predict-eth/issues/150) -- ocean.py interface changes broke READMEs

